### PR TITLE
Small description on concurrency pattern examples

### DIFF
--- a/2021/08/19/01-concurrency-patterns-fan-in/main.go
+++ b/2021/08/19/01-concurrency-patterns-fan-in/main.go
@@ -8,21 +8,24 @@ import (
 	"sync"
 )
 
+// What is the Fan-In concurrency pattern?
+// Consolidation of multiple channels into one channel by multiplexing each recieved value.
 func main() {
-	ch1, err := read("file1.csv")
+	ch1, err := readCSV("file1.csv")
 	if err != nil {
-		panic(fmt.Errorf("Could not read file1 %v", err))
+		panic(fmt.Errorf("Could not read file1 %v\n", err))
 	}
 
-	ch2, err := read("file2.csv")
+	ch2, err := readCSV("file2.csv")
 	if err != nil {
-		panic(fmt.Errorf("Could not read file2 %v", err))
+		panic(fmt.Errorf("Could not read file2 %v\n", err))
 	}
 
 	//-
 
 	exit := make(chan struct{})
 
+	// chM := merge1(ch1, ch2)
 	chM := merge2(ch1, ch2)
 
 	go func() {
@@ -98,10 +101,10 @@ func merge2(cs ...<-chan []string) <-chan []string {
 	return out
 }
 
-func read(file string) (<-chan []string, error) {
+func readCSV(file string) (<-chan []string, error) {
 	f, err := os.Open(file)
 	if err != nil {
-		return nil, fmt.Errorf("opening file %v", err)
+		return nil, fmt.Errorf("opening file %v\n", err)
 	}
 
 	ch := make(chan []string)

--- a/2021/08/19/02-concurrency-patterns-fan-out/main.go
+++ b/2021/08/19/02-concurrency-patterns-fan-out/main.go
@@ -7,10 +7,12 @@ import (
 	"os"
 )
 
+// What is the Fan-Out concurrency pattern?
+// Breakup of one channel into multiple ones by distributing each value.
 func main() {
-	ch1, err := read("file1.csv")
+	ch1, err := readCSV("file1.csv")
 	if err != nil {
-		panic(fmt.Errorf("Could not read file1 %v", err))
+		panic(fmt.Errorf("Could not read file1 %v\n", err))
 	}
 
 	//-
@@ -90,10 +92,10 @@ func merge(cs ...<-chan []string) <-chan []string {
 	return out
 }
 
-func read(file string) (<-chan []string, error) {
+func readCSV(file string) (<-chan []string, error) {
 	f, err := os.Open(file)
 	if err != nil {
-		return nil, fmt.Errorf("opening file %v", err)
+		return nil, fmt.Errorf("opening file %v\n", err)
 	}
 
 	ch := make(chan []string)

--- a/2021/09/02/01-sync/main.go
+++ b/2021/09/02/01-sync/main.go
@@ -11,6 +11,14 @@ import (
 	"golang.org/x/sync/errgroup"
 )
 
+/**
+Concurrency Pattern using errgroup package
+
+What is in errgroup?
+Includes ways to do Synchronization, Error propagation and Context cancelation.
+
+Works for groups of goroutines working on a common task.
+*/
 func main() {
 	wait := waitGroups()
 	// wait := errGroup()

--- a/2021/09/10/01-pipeline/main.go
+++ b/2021/09/10/01-pipeline/main.go
@@ -10,6 +10,12 @@ import (
 	"strings"
 )
 
+/**
+Pipeline concurrency pattern
+What is a Pipeline?
+	...chain of processing elements arranged so that the output
+	of each element is the input of the next one... (from Wikipedia)
+*/
 func main() {
 	recordsC, err := readCSV("file1.csv")
 	if err != nil {
@@ -25,7 +31,7 @@ func main() {
 func readCSV(file string) (<-chan []string, error) {
 	f, err := os.Open(file)
 	if err != nil {
-		return nil, fmt.Errorf("opening file %w", err)
+		return nil, fmt.Errorf("opening file %w\n", err)
 	}
 
 	ch := make(chan []string)


### PR DESCRIPTION
- Adds description texts as comments on code. The texts are taken from the videos, with small changes where necessary.
- Changes the `read` function name to `readCSV`, as was used already on the pipeline pattern example code.
- Adds "\n" to a few `fmt.Errorf`