### PR TITLE
updated redis tutorial readme to escape ? in database env variable

### DIFF
--- a/2021/03/11-golang-microservices-caching-redis/README.md
+++ b/2021/03/11-golang-microservices-caching-redis/README.md
@@ -19,7 +19,7 @@ go mod download
 Then you can run `server.go` with the PostgreSQL and Redis configuration:
 
 ```
-DATABASE_URL=postgres://user:password@localhost:5432/dbname?sslmode=disable \
+DATABASE_URL=postgres://user:password@localhost:5432/dbname\?sslmode=disable \
 REDIS=localhost:6379 \
   go run .
 ```


### PR DESCRIPTION
on mac os ventura 13.1 DATABASE_URL is not getting parsed properly due to ? so when you escape it using \? it works. Took me hours to run the sample so thats why suggesting updated readme.md for other future users.